### PR TITLE
Updated stylus to latest version (0.42.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "nib": "1.0.1",
-    "stylus": "0.41.3",
+    "stylus": "0.42.2",
     "lodash": "2.4.1",
     "logmimosa": "0.6.0"
   },


### PR DESCRIPTION
A bug existed in Stylus version 0.41.3 were @import statements was not treated correctly. This is fixed in 0.42.2 and therefore updated.
